### PR TITLE
Fix elasticache usage

### DIFF
--- a/fake-elasticache
+++ b/fake-elasticache
@@ -6,10 +6,12 @@ require 'eventmachine'
 module FakeElasticache
   module Options
     def parse
+      ip = Resolv.getaddress('memcached')
+
       options = {
         port:    11212,
         bind:    '0.0.0.0',
-        servers: ['memcached|memcached|11211'],
+        servers: ["memcached|#{ip}|11211"],
         version: ENV.fetch('MEMCACHED_VERSION', '2.4.14')
       }
 
@@ -61,7 +63,7 @@ module FakeElasticache
 
     def config_output
       config_string = opts[:servers].join(' ')
-      "CONFIG cluster 0 #{config_string.length}\n1\n#{config_string}\n\nEND\n"
+      "CONFIG cluster 0 #{config_string.length}\r\n1\n#{config_string}\n\r\n END\r\n"
     end
   end
 

--- a/fake-elasticache
+++ b/fake-elasticache
@@ -63,7 +63,7 @@ module FakeElasticache
 
     def config_output
       config_string = opts[:servers].join(' ')
-      "CONFIG cluster 0 #{config_string.length}\r\n1\n#{config_string}\n\r\n END\r\n"
+      "CONFIG cluster 0 #{config_string.length}\r\n1\n#{config_string}\n\r\nEND\r\n"
     end
   end
 


### PR DESCRIPTION
The AWS docs have a space on the line before END. This broke our application locally and a few people have been having issues. Removing the space fixes the application for GO clients. It appears we would need to update our client, but this change is preferable.

> http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.AddingToYourClientLibrary.html

_It also has a lot of commits listed, but for some reason it is everything from the fork._
